### PR TITLE
Feature: Add support for compose service deployment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,21 +1,39 @@
-name: 'Dokploy Deployment'
-description: 'Trigger a Dokploy deployment'
+name: "Dokploy Deployment"
+description: "Trigger a Dokploy deployment"
 branding:
-  icon: 'upload-cloud'
-  color: 'gray-dark'
+  icon: "upload-cloud"
+  color: "gray-dark"
 inputs:
   dokploy_url:
-    description: 'Dokploy base URL, e.g. https://dokploy.example.com'
+    description: "Dokploy base URL, e.g. https://dokploy.example.com"
     required: true
   auth_token:
-    description: 'Dokploy authentication token'
+    description: "Dokploy authentication token"
     required: true
   application_id:
-    description: 'Dokploy application ID'
+    description: "Dokploy application/compose ID"
     required: true
+  service_type:
+    description: "Type of service (application,compose)"
+    required: false
+    default: "application"
+
 runs:
   using: "composite"
   steps:
+    - name: Validate deployment type
+      shell: bash
+      run: |
+        case "${{ inputs.service_type }}" in
+          application|compose)
+            echo "Valid service type: ${{ inputs.service_type }}"
+            ;;
+          *)
+            echo "Invalid service type: ${{ inputs.service_type }}"
+            exit 1
+            ;;
+        esac
+
     - name: Trigger Dokploy deployment
       shell: bash
       env:
@@ -24,15 +42,15 @@ runs:
         DOKPLOY_APPLICATION_ID: ${{ inputs.application_id }}
       run: |
         response=$(curl -X 'POST' \
-          "$DOKPLOY_URL/api/application.deploy" \
+          "$DOKPLOY_URL/api/${{ inputs.service_type }}.deploy" \
           -H 'accept: application/json' \
           -H 'Content-Type: application/json' \
           -H "Authorization: Bearer $DOKPLOY_AUTH_TOKEN" \
-          -d "{\"applicationId\": \"$DOKPLOY_APPLICATION_ID\"}" \
+          -d "{\"${{ inputs.service_type }}Id\": \"$DOKPLOY_APPLICATION_ID\"}" \
           -w "%{http_code}" \
           -o /dev/null \
           -s)
-        
+
         if [ "$response" -ne 200 ]; then
           echo "Deployment failed with status code: $response"
           exit 1

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,13 @@ This GitHub Action triggers a deployment on Dokploy.
 
 e.g. `https://server.example.com`
 
+
+### `service_type`
+
+**Optional** Type of Dokploy service (`compose` or `application`)
+
+**Default** `application`
+
 ## Usage
 
 To use this action, include it in your workflow file as follows:
@@ -40,6 +47,7 @@ jobs:
         auth_token: ${{ secrets.DOKPLOY_AUTH_TOKEN }}
         application_id: ${{ secrets.DOKPLOY_APPLICATION_ID }}
         dokploy_url: ${{ secrets.DOKPLOY_URL }}
+        service_type: application
 ```
 
 ## Contributing


### PR DESCRIPTION
This PR enhances the dokploy-deploy-action by adding support for deploying multiple service types (applicatoin or compose) using a single action. This increases flexibility and streamlines the deployment process.

## Changes
* Added an optional `service_type` input to specify service types in the action.
* Used the `service-type` to modify the dokploy endpoint and payload

## Motivation
The current implementation doesn't allow users to deploy compose applications

## Usage
   ```yaml
   steps:
     - name: Deploy Service
       uses: benbristow/dokploy-deploy-action@0.0.1
         with: 
           service_type: compose
           # existing parameters
```

 ## Backwards Compatibility
 The changes implemented are backwards compatible given that the `service_type` is optional and the default value is `application`